### PR TITLE
Bug fix in About Us contact form

### DIFF
--- a/src/app/about-us/about-us.component.html
+++ b/src/app/about-us/about-us.component.html
@@ -134,7 +134,7 @@
         </div>
         <br><br>
     
-        <form action="mailto:nxp5310@psu.edu"> <!-- the president's email address -->
+        <form action="mailto:nxp5310@psu.edu" method="post" enctype="text/plain"> <!-- the president's email address -->
             
             
 


### PR DESCRIPTION
I edited the About Us contact form to add POST method and encryption type attributes. It should be able to send an email now.